### PR TITLE
Add global Navbar and integrate into app layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Footer from "@/components/Footer";
+import Navbar from "@/components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,6 +25,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Navbar />
         {children}
         <Footer />
       </body>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React, { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { Sun, Moon, Menu, X } from 'lucide-react'
+
+
+export default function Navbar() {
+    const [open, setOpen] = useState(false)
+    const [theme, setTheme] = useState<'light' | 'dark'>('dark')
+
+
+    useEffect(() => {
+        const saved = typeof window !== "undefined" ? localStorage.getItem("site-theme") : null;
+        // declare initial here
+        const initial = saved === "light" || saved === "dark" ? saved : "dark";
+        setTheme(initial);
+
+        if (initial === "dark") {
+            document.documentElement.classList.add("dark");
+        } else {
+            document.documentElement.classList.remove("dark");
+        }
+    }, []);
+
+    function toggleTheme() {
+        const next = theme === 'dark' ? 'light' : 'dark'
+        setTheme(next)
+
+        if (next === 'dark') {
+            document.documentElement.classList.add('dark')
+        } else {
+            document.documentElement.classList.remove('dark')
+        }
+
+        localStorage.setItem('site-theme', next)
+    }
+
+
+    return (
+        <header className="sticky top-0 z-40 bg-zinc-900">
+            <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div className="flex justify-between h-16 items-center">
+                    {/* left: logo + title */}
+                    <div className="flex items-center gap-3">
+                        <Link href="/" className="flex items-center gap-3">
+                            <span className="font-semibold text-gray-900 dark:text-white">LearnX</span>
+                        </Link>
+                    </div>
+
+
+                    {/* center: links (hidden on small) */}
+                    <div className="hidden sm:flex sm:items-center sm:gap-6">
+                        <Link href="/" className="text-gray-700 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white">Home</Link>
+                        <Link href="/create" className="text-gray-700 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white">Create</Link>
+                        <Link href="/roadmap" className="text-gray-700 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white">Roadmap</Link>
+                        <a href="https://github.com/tilakjain619/LearnX" target="_blank" rel="noreferrer" className="text-gray-700 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white">GitHub</a>
+                    </div>
+
+
+                    {/* right: actions */}
+                    <div className="flex items-center gap-3">
+                        <button aria-label="toggle theme" onClick={toggleTheme} className="p-2 rounded-md hover:bg-gray-800 text-white">
+                            {theme === 'dark' ? <Sun size={18} className="text-white" /> : <Moon size={18} className="text-white" />}
+                        </button>
+
+
+                        {/* mobile menu button */}
+                        <button className="sm:hidden p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800" onClick={() => setOpen(o => !o)} aria-expanded={open} aria-label="Open menu">
+                            {open ? <X size={20} /> : <Menu size={20} />}
+                        </button>
+                    </div>
+                </div>
+
+
+                {/* Mobile nav */}
+                {open && (
+                    <div className="sm:hidden mt-2 pb-4 border-t border-gray-200 dark:border-gray-800">
+                        <div className="flex flex-col gap-2 px-2">
+                            <Link href="/" className="block px-3 py-2 rounded-md">Home</Link>
+                            <Link href="/create" className="block px-3 py-2 rounded-md">Create</Link>
+                            <Link href="/roadmap" className="block px-3 py-2 rounded-md">Roadmap</Link>
+                            <a href="https://github.com/tilakjain619/LearnX" target="_blank" rel="noreferrer" className="block px-3 py-2 rounded-md">GitHub</a>
+                        </div>
+                    </div>
+                )}
+            </nav>
+        </header>
+    )
+}


### PR DESCRIPTION
Description:
  - Add a global navigation bar so users can easily navigate between Home, Create, Roadmap, and the GitHub repo.

Issue Fix: #18 

What I changed

1. Added components/Navbar.tsx — responsive, sticky, theme toggle, GitHub link.
2. Included usage snippet for app/layout.tsx to render the navbar across all pages.

After make changes : 
<img width="1363" height="694" alt="issueSolvelearnX01" src="https://github.com/user-attachments/assets/ef0b2444-1bca-4240-ab2f-d4f8039ee7d3" />

Ready for review 